### PR TITLE
qt5 compatibility

### DIFF
--- a/qrest.pro
+++ b/qrest.pro
@@ -15,6 +15,9 @@ linux-* {
 
 QT += core \
     gui
+greaterThan(QT_MAJOR_VERSION, 4) {
+    QT += widgets
+}
 
 HEADERS += src/helpers/localeHelper.h \
     src/gui/widgets/custom/progressPie.h \

--- a/src/gui/widgets/qrestaboutdialog.h
+++ b/src/gui/widgets/qrestaboutdialog.h
@@ -20,7 +20,7 @@
 #ifndef QRESTABOUTDIALOG_H
 #define QRESTABOUTDIALOG_H
 
-#include <QtGui/QDialog>
+#include <QDialog>
 #include "ui_qrestaboutdialog.h"
 
 /**

--- a/src/gui/widgets/qresthelpviewer.h
+++ b/src/gui/widgets/qresthelpviewer.h
@@ -20,7 +20,7 @@
 #ifndef QRESTHELPVIEWER_H
 #define QRESTHELPVIEWER_H
 
-#include <QtGui/QMainWindow>
+#include <QMainWindow>
 #include "ui_qresthelpviewer.h"
 
 /**

--- a/src/gui/widgets/qrestmainwindow.h
+++ b/src/gui/widgets/qrestmainwindow.h
@@ -20,7 +20,7 @@
 #ifndef QRESTMAINWINDOW_H
 #define QRESTMAINWINDOW_H
 
-#include <QtGui/QMainWindow>
+#include <QMainWindow>
 #include "../forms/ui_qrestmainwindow.h"
 #include "../../dp/observer.h"
 

--- a/src/gui/widgets/qrestpreferencesdialog.h
+++ b/src/gui/widgets/qrestpreferencesdialog.h
@@ -20,7 +20,7 @@
 #ifndef QRESTPREFERENCESDIALOG_H
 #define QRESTPREFERENCESDIALOG_H
 
-#include <QtGui/QDialog>
+#include <QDialog>
 #include "ui_qrestpreferencesdialog.h"
 
 /**


### PR DESCRIPTION
Allow to perform a build using Qt5.
needs `widgets` modules and components are moved to `QtWidgets` instead of `QtGui`